### PR TITLE
Position OverlayCloseButton to the corner.

### DIFF
--- a/src/atoms/button/overlay-close-button.story.tsx
+++ b/src/atoms/button/overlay-close-button.story.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
-import OverlayCloseButton from './overlay-close-button'
+import OverlayCloseButton, { CornerButton } from './overlay-close-button'
 
 export default {
     title: 'Atom/Overlay Close Button'
 }
 
 export const basic = () => <OverlayCloseButton />
+
+export const corner = () => <CornerButton />

--- a/src/atoms/button/overlay-close-button.tsx
+++ b/src/atoms/button/overlay-close-button.tsx
@@ -10,8 +10,7 @@ const Button = styled.a`
 
     font-size: 20px;
     position: absolute;
-    // top: 20px;
-    // right: 30px;
+
     padding: 12px;
     line-height: 12px;
     background-color: #2250fc;
@@ -19,7 +18,12 @@ const Button = styled.a`
     cursor: pointer;
     border-radius: 5px;
     color: #fff;
-    transition: opacity .5s, transform .5s
+    transition: opacity .5s, transform .5s;
+`
+
+export const CornerButton = styled(Button)`
+    top: 20px;
+    right: 30px;
 `
 
 export default function OverlayCloseButton () {


### PR DESCRIPTION
Writing up a case to debug extending styles with styled-components.

The icon is not appended as :before to the `<a>` element when extended. 